### PR TITLE
Fix 'Edit this page' links

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -26,13 +26,13 @@ const config = {
           sidebarPath: require.resolve("./sidebars.js"),
           // Please change this to your repo.
           editUrl:
-            "https://github.com/facebook/docusaurus/tree/main/packages/create-docusaurus/templates/shared/",
+            "https://github.com/stjude/learngenomics.dev/tree/main/",
         },
         blog: {
           showReadingTime: true,
           // Please change this to your repo.
           editUrl:
-            "https://github.com/facebook/docusaurus/tree/main/packages/create-docusaurus/templates/shared/",
+            "https://github.com/stjude/learngenomics.dev/tree/main/",
         },
         theme: {
           customCss: require.resolve("./src/css/custom.css"),


### PR DESCRIPTION
"Edit this page" links point to a https://github.com/facebook/docusaurus/ URL (which don't exist, of course). This makes those links point to this repo instead.