### PR TITLE
Typo: Clarification in Biological Foundations / Central Dogma

### DIFF
--- a/docs/01-biological-foundations/02-the-central-dogma.md
+++ b/docs/01-biological-foundations/02-the-central-dogma.md
@@ -13,7 +13,7 @@ process below.
 The key takeaways for our purposes are as follows:
 
 1.  The complete information for replicating cells is preserved in DNA, which holds the
-    instructions for creating proteins and is spread across the chromosomes.
+    instructions for creating proteins.
 
 2.  Before a cell produces a protein, the portion of DNA that encodes the protein is
     used as a template to create Ribonucleic Acid (or **RNA**) molecules through a

--- a/docs/01-biological-foundations/02-the-central-dogma.md
+++ b/docs/01-biological-foundations/02-the-central-dogma.md
@@ -13,7 +13,7 @@ process below.
 The key takeaways for our purposes are as follows:
 
 1.  The complete information for replicating cells is preserved in DNA, which holds the
-    instructions for creating proteins spread across the chromosomes.
+    instructions for creating proteins and is spread across the chromosomes.
 
 2.  Before a cell produces a protein, the portion of DNA that encodes the protein is
     used as a template to create Ribonucleic Acid (or **RNA**) molecules through a


### PR DESCRIPTION
Prior to this commit, the sentence sounds like DNA holds the instructions for creating proteins and that _these proteins_ are spread across the chromosomes.
This commit endeavors to clarify that the _DNA_ is spread across the chromosomes rather than that the _proteins_ are spread across the chromosomes.

**Alternatively**, we could remove "spread across the chromosomes" altogether, because it is not particularly relevant to the takeaways of the Central Dogma. It strikes me as filler words.