### PR TITLE
Fix grammar: bacteria which have DNA instead of has

### DIFF
--- a/docs/01-biological-foundations/01-cells-genomes-dna-chromosomes.md
+++ b/docs/01-biological-foundations/01-cells-genomes-dna-chromosomes.md
@@ -25,7 +25,7 @@ for more information.
 
 Everything in this guide refers to eukaryotic molecular biology, which is the
 study of organisms whose DNA is enclosed within a nucleus. Broadly speaking,
-most familiar species are eukaryotes, except bacteria which has DNA spread
+most familiar species are eukaryotes, except bacteria which have DNA spread
 throughout the cell. At times, this document will be geared towards the
 sequencing of human cells specifically.
 


### PR DESCRIPTION
This PR fixes a small grammar issue in the introduction section of
01-cells-genomes-dna-chromosomes.md.

The sentence previously used "bacteria which has DNA", but since
"bacteria" is plural, it has been corrected to "bacteria which have DNA".

This change improves grammatical accuracy in the documentation.